### PR TITLE
fix: print proper name for init script generation name in GitHub log

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ runs:
         WORKSPACE_PATH: ${{ github.workspace }}
         WRITE_LOG_FILES: ${{ inputs.write-log-files }}
       run: |
+        # Add Gradle init script
         if [[ "$RUNNER_OS" == "Windows" ]]; then
           WORKSPACE_PATH=$(echo "$WORKSPACE_PATH" | sed 's|\\|/|g')
         fi


### PR DESCRIPTION
Currently, it looks like this:

```
Run testlens-app/setup-testlens@ab61ffb1bf434d2ac9df9cbbb20375c8467b9324
Run if [[ "$RUNNER_OS" == "Windows" ]]; then
```