### PR TITLE
feat(rerun): do not fail if no tests get executed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,8 @@ runs:
               if ('true'.equalsIgnoreCase('$WRITE_LOG_FILES')) {
                 task.environment('TESTLENS_LOGS_DIR', logsDir.absolutePath)
               }
+              task.filter.failOnNoMatchingTests = false
+              if (task.hasProperty('failOnNoDiscoveredTests')) task.failOnNoDiscoveredTests = false
               task.addTestListener(new TestListener() {
                 void beforeTest(TestDescriptor __) {}
                 void afterTest(TestDescriptor __, TestResult ___) {}


### PR DESCRIPTION
This may happen if all the tests of a particular re-run are muted.

- `failOnNoMatchingTests=false` makes sure that there is no error if a filter was applied (like `--test someTestName` on the command line)
- `failOnNoDiscoveredTests=false` makes sure that there is no error if no filter was applied (since 9.0.0, before that there was no error)