### PR TITLE
feat: capture env vars as properties file during action run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,6 @@ runs:
         INSTRUMENTATION_VERSION: ${{ inputs.instrumentation-version }}
         RUNNER_OS: ${{ runner.os }}
         JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
-        WORKSPACE_PATH: ${{ github.workspace }}
         WRITE_LOG_FILES: ${{ inputs.write-log-files }}
         SESSION_TIMEOUT_SECONDS: ${{ inputs.session-timeout-seconds }}
       shell: bash

--- a/setup-testlens.sh
+++ b/setup-testlens.sh
@@ -51,7 +51,7 @@ import org.gradle.api.provider.*;
 gradle.beforeProject { project ->
   // Locate the env properties file relative to the build root as seen at runtime
   // so it resolves whether the build runs on the runner or in a container/VM.
-  def rootDir = project.rootProject.rootDir
+  def rootDir = project.rootDir
   def envPropertiesFile = null
   for (def dir = rootDir; dir != null; dir = dir.parentFile) {
     def candidate = new File(dir, '.gradle/testlens-env.properties')

--- a/setup-testlens.sh
+++ b/setup-testlens.sh
@@ -17,6 +17,10 @@ write_env_properties_file() {
   } > "$properties_file"
 }
 
+# Capture environment variables into a properties file in the working directory
+TESTLENS_ENV_PROPERTIES_FILE="$PWD/.testlens-env.properties"
+write_env_properties_file "$TESTLENS_ENV_PROPERTIES_FILE"
+
 # Add Gradle init script
 # Detect Gradle build based on env var, or presence the of settings script
 if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gradle.kts ]]; then
@@ -26,9 +30,6 @@ if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gr
   if [[ -z "$GRADLE_USER_HOME" ]]; then
     GRADLE_USER_HOME="$HOME/.gradle"
   fi
-
-  TESTLENS_ENV_PROPERTIES_FILE="$GRADLE_USER_HOME/init.d/testlens-env.properties"
-  write_env_properties_file "$TESTLENS_ENV_PROPERTIES_FILE"
 
   # normalize file paths on windows
   if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -115,9 +116,6 @@ fi
 # Patch Maven Parent POM
 if [[ -f "pom.xml" ]]; then
   POM_FILE="pom.xml"
-  # trailing Xs must be last for BSD/macOS mktemp; a suffix after them is not substituted
-  TESTLENS_ENV_PROPERTIES_FILE="$(mktemp "${RUNNER_TEMP:-/tmp}/testlens-env-XXXXXX")"
-  write_env_properties_file "$TESTLENS_ENV_PROPERTIES_FILE"
   # shellcheck disable=SC2016
   # SC2016: Single-quoted `${project.build.directory}` is a Maven expression, not a shell variable - it must not be expanded.
   PROFILE_CONTENT="    <profile>

--- a/setup-testlens.sh
+++ b/setup-testlens.sh
@@ -13,7 +13,7 @@ write_env_properties_file() {
   {
     while IFS= read -r var_name; do
       printf '%s=%s\n' "$var_name" "$(escape_for_java_properties "${!var_name}")"
-    done < <(printf '%s\n' "${!GITHUB_@}" "${!RUNNER_@}" "JOB_CHECK_RUN_ID" | sort -u)
+    done < <(printf '%s\n' "${!GITHUB_@}" "${!RUNNER_@}" "JOB_CHECK_RUN_ID" "TESTLENS_GITHUB_TOKEN" | sort -u)
   } > "$properties_file"
 }
 
@@ -33,21 +33,12 @@ if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gr
     # SC2001: sed is intentionally used here over bash parameter expansion for readability,
     # as the bash equivalent `${VAR//\\//}` is visually ambiguous for backslash-to-slash substitution.
     GRADLE_USER_HOME=$(echo "$GRADLE_USER_HOME" | sed 's|\\|/|g')
-    # When running in a shell script (as opposed to inline action YAML), bash on Windows
-    # normalizes paths to Git Bash style (/c/Users/...). The Groovy init script however
-    # runs on the JVM which requires Windows style paths (C:/Users/...).
-    # shellcheck disable=SC2001
-    GRADLE_USER_HOME_GROOVY=$(echo "$GRADLE_USER_HOME" | sed 's|^/\([a-zA-Z]\)/|\1:/|')
-  else
-    GRADLE_USER_HOME_GROOVY="$GRADLE_USER_HOME"
   fi
 
   # write files required by TestLens
   write_env_properties_file "$PWD/.gradle/testlens-env.properties"
   mkdir -p "$GRADLE_USER_HOME/init.d"
-  echo -n "$TESTLENS_GITHUB_TOKEN" > "$GRADLE_USER_HOME"/init.d/TESTLENS_GITHUB_TOKEN
   cat << EOF > "$GRADLE_USER_HOME"/init.d/testlens-init.gradle
-import org.gradle.api.provider.*;
 gradle.beforeProject { project ->
   // Locate the env properties file relative to the build root as seen at runtime
   // so it resolves whether the build runs on the runner or in a container/VM.
@@ -62,9 +53,6 @@ gradle.beforeProject { project ->
     TestLensSetup.configure(project, relativeBuildPath, envPropertiesFile)
   }
 }
-abstract class TestLensGitHubTokenValueSource implements ValueSource<String, ValueSourceParameters.None> {
-  String obtain() { new File('$GRADLE_USER_HOME_GROOVY/init.d/TESTLENS_GITHUB_TOKEN').text }
-}
 final class TestLensSetup {
   static def configure(Project project, String relativeBuildPath, File envPropertiesFile) {
     project.plugins.withId('java') {
@@ -72,7 +60,6 @@ final class TestLensSetup {
         dependencies { runtimeOnly('app.testlens:junit-platform-instrumentation:$INSTRUMENTATION_VERSION') }
       }
     }
-    def providers = project.providers
     project.tasks.withType(Test).configureEach { task ->
       def muteMarker = new File(task.temporaryDir, 'testlens-mute.marker')
       def logsDir = new File(task.temporaryDir, 'testlens-logs')
@@ -80,7 +67,6 @@ final class TestLensSetup {
       task.environment('TESTLENS_PROJECT_ID', '$TESTLENS_PROJECT_ID')
       task.environment('TESTLENS_WORK_UNIT_PATH', workUnitPath)
       task.environment('TESTLENS_MUTE_MARKER_FILE', muteMarker.absolutePath)
-      task.environment('TESTLENS_GITHUB_TOKEN', providers.of(TestLensGitHubTokenValueSource){}.get())
       task.environment('TESTLENS_ENV_PROPERTIES_FILE', envPropertiesFile.absolutePath)
       if ('true'.equalsIgnoreCase('$WRITE_LOG_FILES')) {
         task.environment('TESTLENS_LOGS_DIR', logsDir.absolutePath)
@@ -136,7 +122,6 @@ if [[ -f "pom.xml" ]]; then
             <configuration>
               <environmentVariables>
                 <TESTLENS_PROJECT_ID>$TESTLENS_PROJECT_ID</TESTLENS_PROJECT_ID>
-                <TESTLENS_GITHUB_TOKEN>$TESTLENS_GITHUB_TOKEN</TESTLENS_GITHUB_TOKEN>
                 <TESTLENS_WORK_UNIT_PATH>\${project.name}</TESTLENS_WORK_UNIT_PATH>
                 <TESTLENS_ENV_PROPERTIES_FILE>\${maven.multiModuleProjectDirectory}/.mvn/testlens-env.properties</TESTLENS_ENV_PROPERTIES_FILE>
                 <TESTLENS_LOGS_DIR>$(if [[ $WRITE_LOG_FILES = "true" ]]; then echo '${project.build.directory}/testlens-logs'; fi)</TESTLENS_LOGS_DIR>
@@ -149,7 +134,6 @@ if [[ -f "pom.xml" ]]; then
             <configuration>
               <environmentVariables>
                 <TESTLENS_PROJECT_ID>$TESTLENS_PROJECT_ID</TESTLENS_PROJECT_ID>
-                <TESTLENS_GITHUB_TOKEN>$TESTLENS_GITHUB_TOKEN</TESTLENS_GITHUB_TOKEN>
                 <TESTLENS_WORK_UNIT_PATH>\${project.name}</TESTLENS_WORK_UNIT_PATH>
                 <TESTLENS_ENV_PROPERTIES_FILE>\${maven.multiModuleProjectDirectory}/.mvn/testlens-env.properties</TESTLENS_ENV_PROPERTIES_FILE>
                 <TESTLENS_LOGS_DIR>$(if [[ $WRITE_LOG_FILES = "true" ]]; then echo '${project.build.directory}/testlens-logs'; fi)</TESTLENS_LOGS_DIR>

--- a/setup-testlens.sh
+++ b/setup-testlens.sh
@@ -1,6 +1,22 @@
 #! /usr/bin/env bash
 set -eo pipefail
 
+escape_for_java_properties() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  printf '%s' "$value"
+}
+
+write_env_properties_file() {
+  local properties_file="$1"
+  mkdir -p "$(dirname "$properties_file")"
+  {
+    while IFS= read -r var_name; do
+      printf '%s=%s\n' "$var_name" "$(escape_for_java_properties "${!var_name}")"
+    done < <(printf '%s\n' "${!GITHUB_@}" "${!RUNNER_@}" "JOB_CHECK_RUN_ID" | sort -u)
+  } > "$properties_file"
+}
+
 # Add Gradle init script
 # Detect Gradle build based on env var, or presence the of settings script
 if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gradle.kts ]]; then
@@ -10,6 +26,9 @@ if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gr
   if [[ -z "$GRADLE_USER_HOME" ]]; then
     GRADLE_USER_HOME="$HOME/.gradle"
   fi
+
+  TESTLENS_ENV_PROPERTIES_FILE="$GRADLE_USER_HOME/init.d/testlens-env.properties"
+  write_env_properties_file "$TESTLENS_ENV_PROPERTIES_FILE"
 
   # normalize file paths on windows
   if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -26,15 +45,17 @@ if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gr
     GRADLE_USER_HOME_GROOVY=$(echo "$GRADLE_USER_HOME" | sed 's|^/\([a-zA-Z]\)/|\1:/|')
     # shellcheck disable=SC2001
     WORKSPACE_PATH_GROOVY=$(echo "$WORKSPACE_PATH" | sed 's|^/\([a-zA-Z]\)/|\1:/|')
+    # shellcheck disable=SC2001
+    TESTLENS_ENV_PROPERTIES_FILE_GROOVY=$(echo "$TESTLENS_ENV_PROPERTIES_FILE" | sed 's|^/\([a-zA-Z]\)/|\1:/|')
   else
     GRADLE_USER_HOME_GROOVY="$GRADLE_USER_HOME"
     WORKSPACE_PATH_GROOVY="$WORKSPACE_PATH"
+    TESTLENS_ENV_PROPERTIES_FILE_GROOVY="$TESTLENS_ENV_PROPERTIES_FILE"
   fi
 
   # write files required by TestLens
   mkdir -p "$GRADLE_USER_HOME/init.d"
   echo -n "$TESTLENS_GITHUB_TOKEN" > "$GRADLE_USER_HOME"/init.d/TESTLENS_GITHUB_TOKEN
-  echo -n "$JOB_CHECK_RUN_ID" > "$GRADLE_USER_HOME"/init.d/JOB_CHECK_RUN_ID
   cat << EOF > "$GRADLE_USER_HOME"/init.d/testlens-init.gradle
 import org.gradle.api.provider.*;
 gradle.beforeProject { project ->
@@ -46,8 +67,8 @@ gradle.beforeProject { project ->
 abstract class TestLensGitHubTokenValueSource implements ValueSource<String, ValueSourceParameters.None> {
   String obtain() { new File('$GRADLE_USER_HOME_GROOVY/init.d/TESTLENS_GITHUB_TOKEN').text }
 }
-abstract class TestLensJobCheckRunIdValueSource implements ValueSource<String, ValueSourceParameters.None> {
-  String obtain() { new File('$GRADLE_USER_HOME_GROOVY/init.d/JOB_CHECK_RUN_ID').text }
+abstract class TestLensEnvPropertiesFileValueSource implements ValueSource<String, ValueSourceParameters.None> {
+  String obtain() { '$TESTLENS_ENV_PROPERTIES_FILE_GROOVY' }
 }
 final class TestLensSetup {
   static def configure(Project project, String relativeBuildPath) {
@@ -65,7 +86,7 @@ final class TestLensSetup {
       task.environment('TESTLENS_WORK_UNIT_PATH', workUnitPath)
       task.environment('TESTLENS_MUTE_MARKER_FILE', muteMarker.absolutePath)
       task.environment('TESTLENS_GITHUB_TOKEN', providers.of(TestLensGitHubTokenValueSource){}.get())
-      task.environment('JOB_CHECK_RUN_ID', providers.of(TestLensJobCheckRunIdValueSource){}.get())
+      task.environment('TESTLENS_ENV_PROPERTIES_FILE', providers.of(TestLensEnvPropertiesFileValueSource){}.get())
       if ('true'.equalsIgnoreCase('$WRITE_LOG_FILES')) {
         task.environment('TESTLENS_LOGS_DIR', logsDir.absolutePath)
       }
@@ -94,6 +115,9 @@ fi
 # Patch Maven Parent POM
 if [[ -f "pom.xml" ]]; then
   POM_FILE="pom.xml"
+  # trailing Xs must be last for BSD/macOS mktemp; a suffix after them is not substituted
+  TESTLENS_ENV_PROPERTIES_FILE="$(mktemp "${RUNNER_TEMP:-/tmp}/testlens-env-XXXXXX")"
+  write_env_properties_file "$TESTLENS_ENV_PROPERTIES_FILE"
   # shellcheck disable=SC2016
   # SC2016: Single-quoted `${project.build.directory}` is a Maven expression, not a shell variable - it must not be expanded.
   PROFILE_CONTENT="    <profile>
@@ -120,7 +144,7 @@ if [[ -f "pom.xml" ]]; then
                 <TESTLENS_PROJECT_ID>$TESTLENS_PROJECT_ID</TESTLENS_PROJECT_ID>
                 <TESTLENS_GITHUB_TOKEN>$TESTLENS_GITHUB_TOKEN</TESTLENS_GITHUB_TOKEN>
                 <TESTLENS_WORK_UNIT_PATH>\${project.name}</TESTLENS_WORK_UNIT_PATH>
-                <JOB_CHECK_RUN_ID>$JOB_CHECK_RUN_ID</JOB_CHECK_RUN_ID>
+                <TESTLENS_ENV_PROPERTIES_FILE>$TESTLENS_ENV_PROPERTIES_FILE</TESTLENS_ENV_PROPERTIES_FILE>
                 <TESTLENS_LOGS_DIR>$(if [[ $WRITE_LOG_FILES = "true" ]]; then echo '${project.build.directory}/testlens-logs'; fi)</TESTLENS_LOGS_DIR>
                 $(if [[ -n "$SESSION_TIMEOUT_SECONDS" ]]; then echo "<TESTLENS_SESSION_TIMEOUT_SECONDS>$SESSION_TIMEOUT_SECONDS</TESTLENS_SESSION_TIMEOUT_SECONDS>"; fi)
               </environmentVariables>
@@ -133,7 +157,7 @@ if [[ -f "pom.xml" ]]; then
                 <TESTLENS_PROJECT_ID>$TESTLENS_PROJECT_ID</TESTLENS_PROJECT_ID>
                 <TESTLENS_GITHUB_TOKEN>$TESTLENS_GITHUB_TOKEN</TESTLENS_GITHUB_TOKEN>
                 <TESTLENS_WORK_UNIT_PATH>\${project.name}</TESTLENS_WORK_UNIT_PATH>
-                <JOB_CHECK_RUN_ID>$JOB_CHECK_RUN_ID</JOB_CHECK_RUN_ID>
+                <TESTLENS_ENV_PROPERTIES_FILE>$TESTLENS_ENV_PROPERTIES_FILE</TESTLENS_ENV_PROPERTIES_FILE>
                 <TESTLENS_LOGS_DIR>$(if [[ $WRITE_LOG_FILES = "true" ]]; then echo '${project.build.directory}/testlens-logs'; fi)</TESTLENS_LOGS_DIR>
                 $(if [[ -n "$SESSION_TIMEOUT_SECONDS" ]]; then echo "<TESTLENS_SESSION_TIMEOUT_SECONDS>$SESSION_TIMEOUT_SECONDS</TESTLENS_SESSION_TIMEOUT_SECONDS>"; fi)
               </environmentVariables>

--- a/setup-testlens.sh
+++ b/setup-testlens.sh
@@ -17,10 +17,6 @@ write_env_properties_file() {
   } > "$properties_file"
 }
 
-# Capture environment variables into a properties file in the working directory
-TESTLENS_ENV_PROPERTIES_FILE="$PWD/.testlens-env.properties"
-write_env_properties_file "$TESTLENS_ENV_PROPERTIES_FILE"
-
 # Add Gradle init script
 # Detect Gradle build based on env var, or presence the of settings script
 if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gradle.kts ]]; then
@@ -36,43 +32,41 @@ if [[ -n "$GRADLE_USER_HOME" ]] || [[ -f settings.gradle ]] || [[ -f settings.gr
     # shellcheck disable=SC2001
     # SC2001: sed is intentionally used here over bash parameter expansion for readability,
     # as the bash equivalent `${VAR//\\//}` is visually ambiguous for backslash-to-slash substitution.
-    WORKSPACE_PATH=$(echo "$WORKSPACE_PATH" | sed 's|\\|/|g')
-    # shellcheck disable=SC2001
     GRADLE_USER_HOME=$(echo "$GRADLE_USER_HOME" | sed 's|\\|/|g')
     # When running in a shell script (as opposed to inline action YAML), bash on Windows
     # normalizes paths to Git Bash style (/c/Users/...). The Groovy init script however
     # runs on the JVM which requires Windows style paths (C:/Users/...).
     # shellcheck disable=SC2001
     GRADLE_USER_HOME_GROOVY=$(echo "$GRADLE_USER_HOME" | sed 's|^/\([a-zA-Z]\)/|\1:/|')
-    # shellcheck disable=SC2001
-    WORKSPACE_PATH_GROOVY=$(echo "$WORKSPACE_PATH" | sed 's|^/\([a-zA-Z]\)/|\1:/|')
-    # shellcheck disable=SC2001
-    TESTLENS_ENV_PROPERTIES_FILE_GROOVY=$(echo "$TESTLENS_ENV_PROPERTIES_FILE" | sed 's|^/\([a-zA-Z]\)/|\1:/|')
   else
     GRADLE_USER_HOME_GROOVY="$GRADLE_USER_HOME"
-    WORKSPACE_PATH_GROOVY="$WORKSPACE_PATH"
-    TESTLENS_ENV_PROPERTIES_FILE_GROOVY="$TESTLENS_ENV_PROPERTIES_FILE"
   fi
 
   # write files required by TestLens
+  write_env_properties_file "$PWD/.gradle/testlens-env.properties"
   mkdir -p "$GRADLE_USER_HOME/init.d"
   echo -n "$TESTLENS_GITHUB_TOKEN" > "$GRADLE_USER_HOME"/init.d/TESTLENS_GITHUB_TOKEN
   cat << EOF > "$GRADLE_USER_HOME"/init.d/testlens-init.gradle
 import org.gradle.api.provider.*;
 gradle.beforeProject { project ->
-  String relativeBuildPath = new File('$WORKSPACE_PATH_GROOVY').relativePath(project.rootDir)
-  if (!relativeBuildPath.startsWith('..') && !new File(relativeBuildPath).isAbsolute()) {
-    TestLensSetup.configure(project, relativeBuildPath)
+  // Locate the env properties file relative to the build root as seen at runtime
+  // so it resolves whether the build runs on the runner or in a container/VM.
+  def rootDir = project.rootProject.rootDir
+  def envPropertiesFile = null
+  for (def dir = rootDir; dir != null; dir = dir.parentFile) {
+    def candidate = new File(dir, '.gradle/testlens-env.properties')
+    if (candidate.isFile()) { envPropertiesFile = candidate; break }
+  }
+  if (envPropertiesFile != null) {
+    def relativeBuildPath = envPropertiesFile.parentFile.parentFile.relativePath(rootDir)
+    TestLensSetup.configure(project, relativeBuildPath, envPropertiesFile)
   }
 }
 abstract class TestLensGitHubTokenValueSource implements ValueSource<String, ValueSourceParameters.None> {
   String obtain() { new File('$GRADLE_USER_HOME_GROOVY/init.d/TESTLENS_GITHUB_TOKEN').text }
 }
-abstract class TestLensEnvPropertiesFileValueSource implements ValueSource<String, ValueSourceParameters.None> {
-  String obtain() { '$TESTLENS_ENV_PROPERTIES_FILE_GROOVY' }
-}
 final class TestLensSetup {
-  static def configure(Project project, String relativeBuildPath) {
+  static def configure(Project project, String relativeBuildPath, File envPropertiesFile) {
     project.plugins.withId('java') {
       project.testing.suites.configureEach {
         dependencies { runtimeOnly('app.testlens:junit-platform-instrumentation:$INSTRUMENTATION_VERSION') }
@@ -87,7 +81,7 @@ final class TestLensSetup {
       task.environment('TESTLENS_WORK_UNIT_PATH', workUnitPath)
       task.environment('TESTLENS_MUTE_MARKER_FILE', muteMarker.absolutePath)
       task.environment('TESTLENS_GITHUB_TOKEN', providers.of(TestLensGitHubTokenValueSource){}.get())
-      task.environment('TESTLENS_ENV_PROPERTIES_FILE', providers.of(TestLensEnvPropertiesFileValueSource){}.get())
+      task.environment('TESTLENS_ENV_PROPERTIES_FILE', envPropertiesFile.absolutePath)
       if ('true'.equalsIgnoreCase('$WRITE_LOG_FILES')) {
         task.environment('TESTLENS_LOGS_DIR', logsDir.absolutePath)
       }
@@ -116,6 +110,9 @@ fi
 # Patch Maven Parent POM
 if [[ -f "pom.xml" ]]; then
   POM_FILE="pom.xml"
+  # Writing into .mvn also pins ${maven.multiModuleProjectDirectory} to this directory,
+  # even when Maven is invoked from a subdirectory.
+  write_env_properties_file "$PWD/.mvn/testlens-env.properties"
   # shellcheck disable=SC2016
   # SC2016: Single-quoted `${project.build.directory}` is a Maven expression, not a shell variable - it must not be expanded.
   PROFILE_CONTENT="    <profile>
@@ -141,7 +138,7 @@ if [[ -f "pom.xml" ]]; then
                 <TESTLENS_PROJECT_ID>$TESTLENS_PROJECT_ID</TESTLENS_PROJECT_ID>
                 <TESTLENS_GITHUB_TOKEN>$TESTLENS_GITHUB_TOKEN</TESTLENS_GITHUB_TOKEN>
                 <TESTLENS_WORK_UNIT_PATH>\${project.name}</TESTLENS_WORK_UNIT_PATH>
-                <TESTLENS_ENV_PROPERTIES_FILE>$TESTLENS_ENV_PROPERTIES_FILE</TESTLENS_ENV_PROPERTIES_FILE>
+                <TESTLENS_ENV_PROPERTIES_FILE>\${maven.multiModuleProjectDirectory}/.mvn/testlens-env.properties</TESTLENS_ENV_PROPERTIES_FILE>
                 <TESTLENS_LOGS_DIR>$(if [[ $WRITE_LOG_FILES = "true" ]]; then echo '${project.build.directory}/testlens-logs'; fi)</TESTLENS_LOGS_DIR>
                 $(if [[ -n "$SESSION_TIMEOUT_SECONDS" ]]; then echo "<TESTLENS_SESSION_TIMEOUT_SECONDS>$SESSION_TIMEOUT_SECONDS</TESTLENS_SESSION_TIMEOUT_SECONDS>"; fi)
               </environmentVariables>
@@ -154,7 +151,7 @@ if [[ -f "pom.xml" ]]; then
                 <TESTLENS_PROJECT_ID>$TESTLENS_PROJECT_ID</TESTLENS_PROJECT_ID>
                 <TESTLENS_GITHUB_TOKEN>$TESTLENS_GITHUB_TOKEN</TESTLENS_GITHUB_TOKEN>
                 <TESTLENS_WORK_UNIT_PATH>\${project.name}</TESTLENS_WORK_UNIT_PATH>
-                <TESTLENS_ENV_PROPERTIES_FILE>$TESTLENS_ENV_PROPERTIES_FILE</TESTLENS_ENV_PROPERTIES_FILE>
+                <TESTLENS_ENV_PROPERTIES_FILE>\${maven.multiModuleProjectDirectory}/.mvn/testlens-env.properties</TESTLENS_ENV_PROPERTIES_FILE>
                 <TESTLENS_LOGS_DIR>$(if [[ $WRITE_LOG_FILES = "true" ]]; then echo '${project.build.directory}/testlens-logs'; fi)</TESTLENS_LOGS_DIR>
                 $(if [[ -n "$SESSION_TIMEOUT_SECONDS" ]]; then echo "<TESTLENS_SESSION_TIMEOUT_SECONDS>$SESSION_TIMEOUT_SECONDS</TESTLENS_SESSION_TIMEOUT_SECONDS>"; fi)
               </environmentVariables>

--- a/setup-testlens.sh
+++ b/setup-testlens.sh
@@ -123,9 +123,8 @@ if [[ -f "pom.xml" ]]; then
   PROFILE_CONTENT="    <profile>
       <id>testlens</id>
       <activation>
-        <property>
-          <name>env.CI</name>
-        </property>
+        <!-- workaround for MNG-4917 -->
+        <file><exists>.</exists></file>
       </activation>
       <dependencies>
         <dependency>

--- a/test/env-properties.bats
+++ b/test/env-properties.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load helpers
+load node_modules/bats-support/load
+load node_modules/bats-assert/load
+
+setup() {
+  _common_setup
+  GRADLE_HOME="$TEST_TMP/gradle-home"
+  export GRADLE_USER_HOME="$GRADLE_HOME"
+  GRADLE_ENV_PROPS="$GRADLE_HOME/init.d/testlens-env.properties"
+  unset "${!GITHUB_@}" "${!RUNNER_@}"
+}
+
+@test "captures GITHUB_*, RUNNER_*, and JOB_CHECK_RUN_ID variables" {
+  export GITHUB_REPOSITORY="octo/demo"
+  export RUNNER_NAME="runner-7"
+  export JOB_CHECK_RUN_ID="12345"
+  run "$SCRIPT"
+  assert_contains "$GRADLE_ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
+  assert_contains "$GRADLE_ENV_PROPS" "RUNNER_NAME=runner-7"
+  assert_contains "$GRADLE_ENV_PROPS" "JOB_CHECK_RUN_ID=12345"
+}
+
+@test "does not capture unrelated variables" {
+  export SOME_OTHER_VAR="secret"
+  run "$SCRIPT"
+  assert_not_contains "$GRADLE_ENV_PROPS" "SOME_OTHER_VAR"
+}
+
+@test "backslashes in values are escaped" {
+  export GITHUB_WORKSPACE='C:\work\repo'
+  run "$SCRIPT"
+  assert_contains "$GRADLE_ENV_PROPS" 'GITHUB_WORKSPACE=C:\\work\\repo'
+}
+
+@test "maven build also writes an env properties file with captured vars" {
+  copy_fixture maven-single
+  export GITHUB_REPOSITORY="octo/demo"
+  run "$SCRIPT"
+  assert_success
+  local props
+  props="$(grep -oE '<TESTLENS_ENV_PROPERTIES_FILE>[^<]+' pom.xml | head -1 | sed 's/.*>//')"
+  assert_file "$props"
+  assert_contains "$props" "GITHUB_REPOSITORY=octo/demo"
+}

--- a/test/env-properties.bats
+++ b/test/env-properties.bats
@@ -6,9 +6,7 @@ load node_modules/bats-assert/load
 
 setup() {
   _common_setup
-  GRADLE_HOME="$TEST_TMP/gradle-home"
-  export GRADLE_USER_HOME="$GRADLE_HOME"
-  GRADLE_ENV_PROPS="$GRADLE_HOME/init.d/testlens-env.properties"
+  ENV_PROPS="$WORKDIR/.testlens-env.properties"
   unset "${!GITHUB_@}" "${!RUNNER_@}"
 }
 
@@ -17,21 +15,21 @@ setup() {
   export RUNNER_NAME="runner-7"
   export JOB_CHECK_RUN_ID="12345"
   run "$SCRIPT"
-  assert_contains "$GRADLE_ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
-  assert_contains "$GRADLE_ENV_PROPS" "RUNNER_NAME=runner-7"
-  assert_contains "$GRADLE_ENV_PROPS" "JOB_CHECK_RUN_ID=12345"
+  assert_contains "$ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
+  assert_contains "$ENV_PROPS" "RUNNER_NAME=runner-7"
+  assert_contains "$ENV_PROPS" "JOB_CHECK_RUN_ID=12345"
 }
 
 @test "does not capture unrelated variables" {
   export SOME_OTHER_VAR="secret"
   run "$SCRIPT"
-  assert_not_contains "$GRADLE_ENV_PROPS" "SOME_OTHER_VAR"
+  assert_not_contains "$ENV_PROPS" "SOME_OTHER_VAR"
 }
 
 @test "backslashes in values are escaped" {
   export GITHUB_WORKSPACE='C:\work\repo'
   run "$SCRIPT"
-  assert_contains "$GRADLE_ENV_PROPS" 'GITHUB_WORKSPACE=C:\\work\\repo'
+  assert_contains "$ENV_PROPS" 'GITHUB_WORKSPACE=C:\\work\\repo'
 }
 
 @test "maven build also writes an env properties file with captured vars" {
@@ -39,8 +37,6 @@ setup() {
   export GITHUB_REPOSITORY="octo/demo"
   run "$SCRIPT"
   assert_success
-  local props
-  props="$(grep -oE '<TESTLENS_ENV_PROPERTIES_FILE>[^<]+' pom.xml | head -1 | sed 's/.*>//')"
-  assert_file "$props"
-  assert_contains "$props" "GITHUB_REPOSITORY=octo/demo"
+  assert_contains "$ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
+  assert_contains pom.xml "<TESTLENS_ENV_PROPERTIES_FILE>$ENV_PROPS<"
 }

--- a/test/env-properties.bats
+++ b/test/env-properties.bats
@@ -6,37 +6,52 @@ load node_modules/bats-assert/load
 
 setup() {
   _common_setup
-  ENV_PROPS="$WORKDIR/.testlens-env.properties"
+  GRADLE_ENV_PROPS="$WORKDIR/.gradle/testlens-env.properties"
+  MVN_ENV_PROPS="$WORKDIR/.mvn/testlens-env.properties"
   unset "${!GITHUB_@}" "${!RUNNER_@}"
 }
 
 @test "captures GITHUB_*, RUNNER_*, and JOB_CHECK_RUN_ID variables" {
+  echo "rootProject.name = 'demo'" > settings.gradle
   export GITHUB_REPOSITORY="octo/demo"
   export RUNNER_NAME="runner-7"
   export JOB_CHECK_RUN_ID="12345"
   run "$SCRIPT"
-  assert_contains "$ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
-  assert_contains "$ENV_PROPS" "RUNNER_NAME=runner-7"
-  assert_contains "$ENV_PROPS" "JOB_CHECK_RUN_ID=12345"
+  assert_success
+  assert_contains "$GRADLE_ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
+  assert_contains "$GRADLE_ENV_PROPS" "RUNNER_NAME=runner-7"
+  assert_contains "$GRADLE_ENV_PROPS" "JOB_CHECK_RUN_ID=12345"
 }
 
 @test "does not capture unrelated variables" {
+  echo "rootProject.name = 'demo'" > settings.gradle
   export SOME_OTHER_VAR="secret"
   run "$SCRIPT"
-  assert_not_contains "$ENV_PROPS" "SOME_OTHER_VAR"
+  assert_not_contains "$GRADLE_ENV_PROPS" "SOME_OTHER_VAR"
 }
 
 @test "backslashes in values are escaped" {
+  echo "rootProject.name = 'demo'" > settings.gradle
   export GITHUB_WORKSPACE='C:\work\repo'
   run "$SCRIPT"
-  assert_contains "$ENV_PROPS" 'GITHUB_WORKSPACE=C:\\work\\repo'
+  assert_contains "$GRADLE_ENV_PROPS" 'GITHUB_WORKSPACE=C:\\work\\repo'
 }
 
-@test "maven build also writes an env properties file with captured vars" {
+@test "gradle init script resolves the env properties file at runtime, not a runner path" {
+  echo "rootProject.name = 'demo'" > settings.gradle
+  run "$SCRIPT"
+  assert_success
+  local init="$HOME/.gradle/init.d/testlens-init.gradle"
+  assert_contains "$init" ".gradle/testlens-env.properties"
+  # the runner-absolute path must not be baked in
+  assert_not_contains "$init" "$WORKDIR/.gradle/testlens-env.properties"
+}
+
+@test "maven build writes the env properties file under .mvn and references it via a runtime property" {
   copy_fixture maven-single
   export GITHUB_REPOSITORY="octo/demo"
   run "$SCRIPT"
   assert_success
-  assert_contains "$ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
-  assert_contains pom.xml "<TESTLENS_ENV_PROPERTIES_FILE>$ENV_PROPS<"
+  assert_contains "$MVN_ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
+  assert_contains pom.xml '<TESTLENS_ENV_PROPERTIES_FILE>${maven.multiModuleProjectDirectory}/.mvn/testlens-env.properties</TESTLENS_ENV_PROPERTIES_FILE>'
 }

--- a/test/env-properties.bats
+++ b/test/env-properties.bats
@@ -11,16 +11,18 @@ setup() {
   unset "${!GITHUB_@}" "${!RUNNER_@}"
 }
 
-@test "captures GITHUB_*, RUNNER_*, and JOB_CHECK_RUN_ID variables" {
+@test "captures GITHUB_*, RUNNER_*, JOB_CHECK_RUN_ID, and TESTLENS_GITHUB_TOKEN variables" {
   echo "rootProject.name = 'demo'" > settings.gradle
   export GITHUB_REPOSITORY="octo/demo"
   export RUNNER_NAME="runner-7"
   export JOB_CHECK_RUN_ID="12345"
+  export TESTLENS_GITHUB_TOKEN="some-token"
   run "$SCRIPT"
   assert_success
   assert_contains "$GRADLE_ENV_PROPS" "GITHUB_REPOSITORY=octo/demo"
   assert_contains "$GRADLE_ENV_PROPS" "RUNNER_NAME=runner-7"
   assert_contains "$GRADLE_ENV_PROPS" "JOB_CHECK_RUN_ID=12345"
+  assert_contains "$GRADLE_ENV_PROPS" "TESTLENS_GITHUB_TOKEN=some-token"
 }
 
 @test "does not capture unrelated variables" {

--- a/test/gradle.bats
+++ b/test/gradle.bats
@@ -44,13 +44,20 @@ setup() {
     "app.testlens:junit-platform-instrumentation:9.9.9"
 }
 
-@test "init script contains project id and workspace path" {
+@test "init script contains project id" {
   export TESTLENS_PROJECT_ID="octo/demo-repo"
   export GRADLE_USER_HOME="$GRADLE_HOME"
   run "$SCRIPT"
   local init="$GRADLE_HOME/init.d/testlens-init.gradle"
   assert_contains "$init" "'octo/demo-repo'"
-  assert_contains "$init" "new File('$WORKDIR')"
+}
+
+@test "init script resolves the env properties file at runtime, not a runner-absolute path" {
+  export GRADLE_USER_HOME="$GRADLE_HOME"
+  run "$SCRIPT"
+  local init="$GRADLE_HOME/init.d/testlens-init.gradle"
+  assert_contains "$init" "new File(dir, '.gradle/testlens-env.properties')"
+  assert_not_contains "$init" "$WORKDIR/.gradle/testlens-env.properties"
 }
 
 @test "token file contains the raw token" {
@@ -76,20 +83,11 @@ setup() {
   assert_contains "$init" "if (!'30'.empty)"
 }
 
-@test "windows backslash workspace path is converted to JVM style" {
-  export GRADLE_USER_HOME="$GRADLE_HOME"
+@test "windows backslash GRADLE_USER_HOME is converted to JVM style in the token path" {
   export RUNNER_OS="Windows"
-  export WORKSPACE_PATH='C:\work\repo'
+  export GRADLE_USER_HOME='C:\gradle\home'
   run "$SCRIPT"
   assert_success
-  assert_contains "$GRADLE_HOME/init.d/testlens-init.gradle" "new File('C:/work/repo')"
-}
-
-@test "git-bash style workspace path is converted to JVM style" {
-  export GRADLE_USER_HOME="$GRADLE_HOME"
-  export RUNNER_OS="Windows"
-  export WORKSPACE_PATH='/c/work/repo'
-  run "$SCRIPT"
-  assert_success
-  assert_contains "$GRADLE_HOME/init.d/testlens-init.gradle" "new File('c:/work/repo')"
+  assert_contains "C:/gradle/home/init.d/testlens-init.gradle" \
+    "new File('C:/gradle/home/init.d/TESTLENS_GITHUB_TOKEN')"
 }

--- a/test/gradle.bats
+++ b/test/gradle.bats
@@ -60,14 +60,6 @@ setup() {
   assert_not_contains "$init" "$WORKDIR/.gradle/testlens-env.properties"
 }
 
-@test "token file contains the raw token" {
-  export TESTLENS_GITHUB_TOKEN="some-token"
-  export GRADLE_USER_HOME="$GRADLE_HOME"
-  run "$SCRIPT"
-  assert_file "$GRADLE_HOME/init.d/TESTLENS_GITHUB_TOKEN"
-  assert_equal "$(cat "$GRADLE_HOME/init.d/TESTLENS_GITHUB_TOKEN")" "some-token"
-}
-
 @test "log-files switch is included in init script" {
   export GRADLE_USER_HOME="$GRADLE_HOME"
   export WRITE_LOG_FILES="true"
@@ -83,11 +75,10 @@ setup() {
   assert_contains "$init" "if (!'30'.empty)"
 }
 
-@test "windows backslash GRADLE_USER_HOME is converted to JVM style in the token path" {
+@test "windows backslash GRADLE_USER_HOME is normalized to forward slashes" {
   export RUNNER_OS="Windows"
-  export GRADLE_USER_HOME='C:\gradle\home'
+  export GRADLE_USER_HOME="$WORKDIR\\gradle\\home"
   run "$SCRIPT"
   assert_success
-  assert_contains "C:/gradle/home/init.d/testlens-init.gradle" \
-    "new File('C:/gradle/home/init.d/TESTLENS_GITHUB_TOKEN')"
+  assert_file "$WORKDIR/gradle/home/init.d/testlens-init.gradle"
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -27,6 +27,10 @@ teardown() {
   rm -rf "$TEST_TMP"
 }
 
+copy_fixture() {
+  cp -R "$FIXTURES/$1/." "$WORKDIR/"
+}
+
 assert_file() {
   [ -f "$1" ] || { echo "expected file to exist: $1"; return 1; }
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -17,7 +17,6 @@ _common_setup() {
   mkdir -p "$HOME"
 
   export RUNNER_OS="Linux"
-  export WORKSPACE_PATH="$WORKDIR"
 
   cd "$WORKDIR"
 }

--- a/test/maven.bats
+++ b/test/maven.bats
@@ -8,10 +8,6 @@ setup() {
   _common_setup
 }
 
-copy_fixture() {
-  cp -R "$FIXTURES/$1/." "$WORKDIR/"
-}
-
 @test "profile is inserted into an existing <profiles> block" {
   copy_fixture maven-with-profiles
   run "$SCRIPT"


### PR DESCRIPTION
To avoid problems with running tests in Docker containers or VMs, the
environment variables that are inherent to thee GitHub Actions
environment (`GITHUB_*`, `RUNNER_*`) and the custom `JOB_CHECK_RUN_ID`
are now captured by the action. The file is then read by the
instrumentation during test execution rather than relying on the env
vars being propagated.